### PR TITLE
Fix path to UsingROSonWindows.md

### DIFF
--- a/GettingStarted/NewToROS.md
+++ b/GettingStarted/NewToROS.md
@@ -3,5 +3,5 @@ The Robot Operating System is a powerful tool for creating Robots with advanced 
 
 To support the new ROS user, the ROS community create a set of tutortials which walk through the basics through advanced usage of ROS. Visit the [Tutorial Wiki](http://wiki.ros.org/ROS/Tutorials). 
 
-These tutorials were written for ROS on Linux. While running through the tutorials, please refer to [Using ROS for Windows](GettingStarted/UsingROSonWindows.md).
+These tutorials were written for ROS on Linux. While running through the tutorials, please refer to [Using ROS for Windows](UsingROSonWindows.md).
 


### PR DESCRIPTION
The link on  the [New ROS Users page](https://ms-iot.github.io/ROSOnWindows/GettingStarted/NewToROS.html) to the [Using ROS on Windows page](https://ms-iot.github.io/ROSOnWindows/GettingStarted/GettingStarted/UsingROSonWindows.md) has an extra "GettingStarted" in the URL giving a 404. This PR fixes the path.