### PR TITLE
Add Continuous Integration page for ROS on Windows

### DIFF
--- a/GettingStarted/SetupCI.md
+++ b/GettingStarted/SetupCI.md
@@ -1,0 +1,9 @@
+![ROS Logo](http://www.ros.org/wp-content/uploads/2013/10/rosorg-logo1.png)
+
+> ROS on Windows is experimental.
+
+# Set up Continuous Integration with ROS on Windows
+
+To all ROS package maintainers, we encourage to utilize `ROS on Windows` to continuously keep the code stay stable on Windows system. Here are projects which help you easily getting started:
+
+* [seanyen-msft/rosonwindows_ci](http://github.com/seanyen-msft/rosonwindows_ci): This project defines Azure DevOps build templates, which you can simply include it in your ROS project.

--- a/GettingStarted/SetupCI.md
+++ b/GettingStarted/SetupCI.md
@@ -6,4 +6,4 @@
 
 To all ROS package maintainers, we encourage to utilize `ROS on Windows` to continuously keep the code stay stable on Windows system. Here are projects which help you easily getting started:
 
-* [seanyen-msft/rosonwindows_ci](http://github.com/seanyen-msft/rosonwindows_ci): This project defines Azure DevOps build templates, which you can simply include it in your ROS project.
+* [rosonwindows_ci](http://github.com/seanyen-msft/rosonwindows_ci): This project defines Azure DevOps build templates, which you can simply include it in your ROS project.

--- a/index.md
+++ b/index.md
@@ -26,6 +26,7 @@ Microsoft will host the Windows builds for ROS1 and shortly ROS2, as well as pro
 + [Help and Troubleshooting](GettingStarted/Troubleshooting.md)
 + [Getting Started with Turtlebot3](Turtlebot/Turtlebot3.md)
 + [Getting Started with Moveit! and UR3](Moveit/UR3.md)
++ [Continuous Integration with ROS on Windows](GettingStarted/SetupCI.md)
 + [About the Azure DevOps buildfarm for ROS on Windows](Build/buildfarm.md)
 + [Buiding ROS for Windows from Source](Build/fromsource.md)
 


### PR DESCRIPTION
* Add a page to list projects useful to set up CI with ROS on Windows.