### PR TITLE
minor style fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Visit https://aka.ms/ros/docs to read the generated documentation.
 
 To test this generated HTML pages locally on your machine, you need a `Python` environment and run `MkDocs` tool.
 
-```
+```no-highlight
 :: git clone this repository.
 :: change directory to the repository root.
 pip install mkdocs

--- a/docs/Build/fromsource.md
+++ b/docs/Build/fromsource.md
@@ -4,11 +4,11 @@ As an alternative to using Chocolatey, ROS for Windows can also be [installed fr
 
 ## ROS Environment Command Prompt
 When running ROS, open an elevated Command Prompt with the following setup:
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 ```
 
 If you are building catkin projects, use the Visual Studio x64 command line shortcut that was created earlier to launch a Command Prompt or execute the following command in the current Command Prompt to [make Visual Studio build tools discoverable](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/how-to-set-environment-variables-for-the-visual-studio-command-line) for CMake:
-```
+```no-highlight
 "c:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64
 ```

--- a/docs/Build/source.md
+++ b/docs/Build/source.md
@@ -16,25 +16,35 @@ These tools are used to facilitate the download and management of ROS packages a
 
 If you are using a non-Debian system you need to make sure that you have all build tools (compiler, CMake, etc.) installed. You can install all ROS Python tools via PIP:
 
-    pip install -U rosdep rosinstall_generator wstool rosinstall
-    curl --output requirements.txt -L https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdistro_cache/catkin-requirements.txt
-    pip install -U --no-deps --force-reinstall -r requirements.txt
+```no-highlight
+pip install -U rosdep rosinstall_generator wstool rosinstall
+curl --output requirements.txt -L https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdistro_cache/catkin-requirements.txt
+pip install -U --no-deps --force-reinstall -r requirements.txt
+```
 
 If there are errors with this or the rosdep step below, your system's version of pip may be out-of-date. Use your system's package management to update it, or use it to update itself:
-    
-    python -m pip install -U pip setuptools
+
+```no-highlight
+python -m pip install -U pip setuptools
+```
 
 ### Initializing rosdep
-    rosdep init
-    curl --output 10-ms-iot.list -L https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list
-    copy 10-ms-iot.list c:\etc\ros\rosdep\sources.list.d
-    rosdep update
+
+```no-highlight
+rosdep init
+curl --output 10-ms-iot.list -L https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/rosdep/sources.list.d/10-ms-iot.list
+copy 10-ms-iot.list c:\etc\ros\rosdep\sources.list.d
+rosdep update
+```
 
 The `10-ms-iot.list` points to the rosdep database of ROS for Windows and it will be evaulated before the default source list.
 
 ### Configure Chocolatey sources
-    choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1
-    choco source disable -n=chocolatey
+
+```no-highlight
+choco source add -n=ros-win -s="https://roswin.azurewebsites.net/api/v2" --priority=1
+choco source disable -n=chocolatey
+```
 
 This will add roswin Chocolatey server as a source to discover libraries and tools. Also disable the default one to avoid any potential package naming conflicts.
 
@@ -44,29 +54,37 @@ Start by building the core ROS packages.
 ### Create a catkin Workspace
 In order to build the core packages, you will need a catkin workspace. Create one now:
 
-    mkdir c:\ros_catkin_ws
-    cd c:\ros_catkin_ws
+```no-highlight
+mkdir c:\ros_catkin_ws
+cd c:\ros_catkin_ws
+```
 
 Next we will want to fetch the core packages so we can build them. We will use wstool for this. Select the wstool command for the particular variant you want to install:
 
 **Desktop Install (recommended):** ROS, rqt, rviz, and robot-generic libraries
 
-    set ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml
-    rosinstall_generator desktop --rosdistro melodic --deps --upstream-development > melodic-desktop.rosinstall
-    wstool init src melodic-desktop.rosinstall
+```no-highlight
+set ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml
+rosinstall_generator desktop --rosdistro melodic --deps --upstream-development > melodic-desktop.rosinstall
+wstool init src melodic-desktop.rosinstall
+```
 
 **ROS-Comm: (Bare Bones)** ROS package, build, and communication libraries. No GUI tools.
 
-    set ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml
-    rosinstall_generator ros_comm --rosdistro melodic --deps --upstream-development > melodic-ros_comm.rosinstall
-    wstool init src melodic-ros_comm.rosinstall
+```no-highlight
+set ROSDISTRO_INDEX_URL=https://raw.githubusercontent.com/ms-iot/rosdistro-db/init_windows/index.yaml
+rosinstall_generator ros_comm --rosdistro melodic --deps --upstream-development > melodic-ros_comm.rosinstall
+wstool init src melodic-ros_comm.rosinstall
+```
 
 This will add all of the catkin packages in the given variant and then fetch the sources into the ~/ros_catkin_ws/src directory. The command will take a few minutes to download all of the core ROS packages into the src folder.
 
 ### Resolving Dependencies
 Before you can build your catkin workspace you need to make sure that you have all the required dependencies. We use the rosdep tool for this:
 
-    rosdep install --from-paths src --ignore-src --rosdistro melodic -r -y
+```no-highlight
+rosdep install --from-paths src --ignore-src --rosdistro melodic -r -y
+```
 
 This will look at all of the packages in the src directory and find all of the dependencies they have. Then it will recursively install the dependencies.
 
@@ -79,7 +97,7 @@ Once it has completed downloading the packages and resolving the dependencies yo
 
 Invoke catkin_make_isolated:
 
-```
+```no-highlight
 set PATH=c:\opt\rosdeps\x64\bin;%PATH%
 
 copy ".\src\catkin\bin\catkin_make_isolated" ".\src\catkin\bin\catkin_make_isolated.py"
@@ -93,8 +111,6 @@ python .\src\catkin\bin\catkin_make_isolated.py --use-nmake --install ^
 
 Now the packages should have been installed to `c:/opt/ros/melodic/x64` or to wherever you specified with the --install-space argument. If you look in that directory you will see that a setup.bash file have been generated. To utilize the things installed there simply source that file like so:
  
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 ```
-
-

--- a/docs/GettingStarted/AddingVCPKG.md
+++ b/docs/GettingStarted/AddingVCPKG.md
@@ -5,7 +5,7 @@ vcpkg has thousands of recipies for many different cross platform libraries. If 
 ## Porting a C++ Dependency with vcpkg
 Before you begin, you'll want to fork vcpkg into your github account. Next, Fix up your the ROS environment to use your fork.
 
-```
+```no-highlight
 cd c:\opt\vcpkg
 git remote add upstream https://github.com/microsoft/vcpkg
 git remote set-url origin https://github.com/<your github>/vcpkg
@@ -19,7 +19,7 @@ Create a folder for the package you'd like to port, then add `CONTROL` and `port
 
 *CONTROL*
 
-```
+```no-highlight
 Source: <name>
 Version: <latest release version>
 Homepage: https://github.com/<organization>/<project>
@@ -28,7 +28,7 @@ Description: <Description from github>
 
 *portfile.cmake*
 
-```
+```no-highlight
 include(vcpkg_common_functions)
 
 vcpkg_from_github(
@@ -51,7 +51,7 @@ Then build with `vcpkg build <project>:x64-windows`
 
 Which will error because of the SHA512 hash mismatch:
 
-```
+```no-highlight
   File does not have expected hash:
 
           File path: [ C:/opt/vcpkg/downloads/temp/<package> ]
@@ -61,7 +61,7 @@ Which will error because of the SHA512 hash mismatch:
 
 Which is replaced in the *portfile* above:
 
-```
+```no-highlight
     SHA512 02a61de205bd1dd116677cf4c530d7adb689442252aeafdc549d54531a62ab10e999062403ddb8aed3d89e4f248ad10c0998739b33004ec02e9914150854d47c
 ```
 Then build again with `vcpkg build <package>:x64-windows`
@@ -74,7 +74,7 @@ We now need to change some code in order to make mavlink build correctly on Wind
 
 Seed the patch by adding the original unpacked sources (this won't be checked in):
 
-```
+```no-highlight
 cd c:\opt\vcpkg\buildtrees\<package>
 git init
 git add .
@@ -84,14 +84,14 @@ git commit -m "create patch"
 Next, fix the sources and attempt to build. Once builds complete and testing succeeds, you can create a vcpkg patch:
 
 
-```
+```no-highlight
 cd c:\opt\vcpkg\buildtrees\<package>\....
 git diff > ..\..\..\..\ports\<port>\<path name>.patch
 ```
 
 And include it in the portfile:
 
-```
+```no-highlight
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO <organization>/<project>

--- a/docs/GettingStarted/PortingANode.md
+++ b/docs/GettingStarted/PortingANode.md
@@ -25,7 +25,7 @@ In order for a ROS1 node to be ported to Windows, it must first support ROS Melo
 
 1. On github.com, fork `https://github.com/<organization>/<project>` into your personal github repo
 1. Create a workspace and clone:
-```
+```no-highlight
 mkdir c:\ws\ros_ws\src
 cd c:\ws\ros_ws\src
 git clone https://github.com/<your github>/<project>
@@ -40,13 +40,13 @@ On Windows, the Binary package manager [Chocolatey](https://chocolatey.org/) &ne
 
 In the workspace, use `rosdep` to resolve dependencies
 
-```
+```no-highlight
 rosdep update
 rosdep install --from-paths src --ignore-src -r -y
 ```
 
 You may see the following output indicating missing dependencies:
-```
+```no-highlight
 ERROR: the following packages/stacks could not have their rosdep keys resolved
 to system dependencies:
 <package: No definition of [<dependent library>] for OS [windows]
@@ -61,7 +61,7 @@ Take note of special instructions printed while running `rosdep` - these may be 
 # Missing ROS Messages
 Many ROS Messages are not packaged as binary distributions. These can simply be cloned into the repo. 
 
-```
+```no-highlight
 cd c:\ws\ros_ws\src
 git clone https://github.com/<dependent package organization>/<depdnent package>
 cd ..

--- a/docs/GettingStarted/UsingROSonWindows.md
+++ b/docs/GettingStarted/UsingROSonWindows.md
@@ -7,7 +7,7 @@ To consume a ROS node, we recommend the following workflow:
 * Determine if there is a binary release of the ROS node.
     * Using [ROS Wiki](http://wiki.ros.org) &nearr;, locate the binary release name and attempt to install using chocolatey. 
     * If this succeeds, then you are all set!
-```
+```no-highlight
 choco install ros-melodic-<project>
 ```
 * If there isn't a binary release, determine if there is a source only distribution. 
@@ -17,7 +17,7 @@ choco install ros-melodic-<project>
 
 * If it has a `windows`, `init_windows` or similar branch 
    * Clone that branch locally into a catkin workspace
-```
+```no-highlight
 mkdir c:\ws\test_ws
 cd c:\ws\test_ws
 git clone -b init_windows http://github.com/<organization>/<project>
@@ -28,7 +28,7 @@ git clone -b init_windows http://github.com/<organization>/<project>
   * If Windows is not enabled for the ROS node, check to see if Microsoft's ms-iot Github organization has a fork of that project and working on a port.
       * See if there is a `<project>` fork on http://github.com/ms-iot
       * If it does, clone that into your catkin workspace
-```
+```no-highlight
 mkdir c:\ws\test_ws
 cd c:\ws\test_ws
 git clone -b init_windows http://github.com/ms-iot/<project>

--- a/docs/GettingStarted/UsingVCPKG.md
+++ b/docs/GettingStarted/UsingVCPKG.md
@@ -7,7 +7,7 @@ Often the name of a a library on Linux differs from the name on vcpkg. In order 
 * Fork [https://github.com/ms-iot/rosdistro-db](https://github.com/ms-iot/rosdistro-db) &nearr; into your github account, if you haven't already
 * Create a file called `0-update.list` in `c:\opt\ros\melodic\x64\etc\ros\rosdep\sources.list.d`
 * In this file, add a line which points to your fork.
-```
+```no-highlight
 # os-specific listings first
 yaml https://raw.githubusercontent.com/<your github>/rosdistro-db/init_windows/rosdep/win-chocolatey.yaml windows
 yaml https://raw.githubusercontent.com/<your github>/rosdistro-db/init_windows/rosdep/vcpkg.yaml windows
@@ -16,14 +16,14 @@ yaml https://raw.githubusercontent.com/<your github>/rosdistro-db/init_windows/r
   The format of the vcpkg.yaml:
 
 `Python`
-```
+```no-highlight
 <python-package-name>:
     windows:
       pip:
         packages: [<python-package-name-in-pip>]
 ```
   `C++`
-```
+```no-highlight
   <linux--package-name>:
     windows:
       vcpkg:
@@ -31,12 +31,12 @@ yaml https://raw.githubusercontent.com/<your github>/rosdistro-db/init_windows/r
 ```
 
 * Update rosdeps on your computer.
-```
+```no-highlight
 rosdep update
 rosdep install --from-paths src --ignore-src -r -y
 ```
 You'll see that the dependency resolves correctly. However, you may be provided with specific instructions for using that library in ROS nodes:
-```
+```no-highlight
 The package <library>:x64-windows provides CMake targets:
 
     find_package(<package> CONFIG REQUIRED)

--- a/docs/Moveit/UR3.md
+++ b/docs/Moveit/UR3.md
@@ -1,22 +1,22 @@
-# Getting Started with Moveit! and UR3 on Windows
-Getting Started with the Moveit! and UR3 on Windows. If you are new to Moveit! or you don't have a real robot, check out [Moveit! Tutorials on Windows](moveit_tutorials.md).
+# Getting Started with MoveIt and UR3 on Windows
+Getting Started with the MoveIt and UR3 on Windows. If you are new to MoveIt or you don't have a real robot, check out [MoveIt Tutorials on Windows](moveit_tutorials.md).
 
 ## Prerequisite
 * This guide assumes you had hands-on experience on running ROSOnWindows from this document. (https://ms-iot.github.io/ROSOnWindows/GettingStarted/Setup.html)
 
 * This guide requires you have an Universal Robot UR3 with a software version (3.x)
 
-## Moveit! and UR3 on Windows Installation
+## MoveIt and UR3 on Windows Installation
 First, you can get started by installing moveit related packages from ROSOnWindows Chocolatey server.
 (open a command prompt as admin)
-```
+```no-highlight
 choco upgrade ros-melodic-desktop_full -y
 choco upgrade ros-melodic-moveit -y
 ```
 
 Then, create a workspace, checkout and build the Universal Robot Driver for UR3.
 (open a command prompt as admin)
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 mkdir c:\catkin_ws\src
 cd c:\catkin_ws\src
@@ -34,7 +34,7 @@ Now let's run it! In this example, it requires three launch files to run: One is
 
 Let's start the UR3 driver stack:
 (open a command prompt as admin)
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 c:\catkin_ws\devel\setup.bat
 roslaunch ur_modern_driver ur3_bringup.launch robot_ip:=IP_OF_THE_ROBOT use_lowbandwidth_trajectory_follower:=true
@@ -42,7 +42,7 @@ roslaunch ur_modern_driver ur3_bringup.launch robot_ip:=IP_OF_THE_ROBOT use_lowb
 
 Second, run the UR3 motion planning:
 (open a command prompt as admin)
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 c:\catkin_ws\devel\setup.bat
 roslaunch ur3_moveit_config ur3_moveit_planning_execution.launch
@@ -50,7 +50,7 @@ roslaunch ur3_moveit_config ur3_moveit_planning_execution.launch
 
 Finally, run the visualization tool:
 (open a command prompt as admin)
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 c:\catkin_ws\devel\setup.bat
 roslaunch ur3_moveit_config moveit_rviz.launch config:=true
@@ -61,16 +61,17 @@ roslaunch ur3_moveit_config moveit_rviz.launch config:=true
 Now you are ready to move the robot arm in the visualization tool and start planning and see your arm moving in action!
 
 ## Troubleshoot
-1. The arm fails to move and `Invalid Trajectory: start point deviates from current robot state more than ...` shows in motion planning console window. It is likely the default value of [allowed_start_tolerance](http://moveit.ros.org/moveit!/ros/2017/01/03/firstIndigoRelease.html) being too small for you. Before figuring out a reasonable value,  edit `ur3_moveit_config/launch/move_group.launch` and adding `allowed_start_tolerance` can help:
+1. The arm fails to move and `Invalid Trajectory: start point deviates from current robot state more than ...` shows in motion planning console window. It is likely the default value of [allowed_start_tolerance](http://moveit.ros.org/MoveIt/ros/2017/01/03/firstIndigoRelease.html) being too small for you. Before figuring out a reasonable value,  edit `ur3_moveit_config/launch/move_group.launch` and adding `allowed_start_tolerance` can help:
 
-<pre>
- &lt;node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)"&gt;
+```xml
+<node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group"
+      type="move_group" respawn="false" output="screen" args="$(arg command_args)">
   ...
-  &lt;param name="trajectory_execution/allowed_start_tolerance" value="0.0"/&gt; &lt;!-- default 0.01, disable 0.0 --&gt;
- &lt;/node&gt;
-</pre>
-
+  <!-- default 0.01, disable 0.0 -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.0"/>
+</node>
+```
 
 ## More Information
 * [ur_modern_driver](https://github.com/ms-iot/ur_modern_driver)
-* [Moveit! Tutorials](https://ros-planning.github.io/moveit_tutorials/)
+* [MoveIt Tutorials](https://ros-planning.github.io/moveit_tutorials/)

--- a/docs/Moveit/moveit_tutorials.md
+++ b/docs/Moveit/moveit_tutorials.md
@@ -1,19 +1,20 @@
-# Moveit! Tutorials on Windows
-This guide is to show you how to prepare a workspace (for ROS on Windows) for your Moveit! tutorials. Find out more about Moveit!, visit [here](https://ros-planning.github.io/moveit_tutorials/index.html).
+# MoveIt Tutorials on Windows
+This guide is to show you how to prepare a workspace (for ROS on Windows) for your MoveIt tutorials. Find out more about MoveIt, visit [here](https://ros-planning.github.io/moveit_tutorials/index.html).
 
-## Moveit! Binary Installation on Windows
-First, download the ROS on Windows with Moveit! packages.
+## MoveIt Binary Installation on Windows
+First, download the ROS on Windows with MoveIt packages.
 (open a command prompt as admin)
 
-```
+```no-highlight
 choco upgrade ros-melodic-moveit -y
 ```
 
-## Create Workspace for Moveit! Tutorials
+## Create Workspace for MoveIt Tutorials
 Then, let's download the example code to your workspace.
 
 (open a command prompt as admin)
-```
+
+```no-highlight
 mkdir c:\moveit_ws\src
 cd c:\moveit_ws\src
 catkin_init_workspace
@@ -26,9 +27,9 @@ catkin_make
 
 After it is built, source the catkin workspace.
 
-```
+```no-highlight
 c:\moveit_ws\devel\setup.bat
 ```
 
-## Getting Started with Moveit! Tutorials
-Now you are ready to continue the journal on [Moveit! Tutorials](https://ros-planning.github.io/moveit_tutorials/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).
+## Getting Started with MoveIt Tutorials
+Now you are ready to continue the journal on [MoveIt Tutorials](https://ros-planning.github.io/moveit_tutorials/doc/quickstart_in_rviz/quickstart_in_rviz_tutorial.html).

--- a/docs/Porting/Cookbook.md
+++ b/docs/Porting/Cookbook.md
@@ -3,21 +3,21 @@ While every effort has been made to reduce the effort needed to support ROS node
 there will inevitably be required changes between platforms. This cookbook is intended to collect common issues and recommended solutions.
 
 ## Windows and Linux Differences
-## C++ 17
+### C++ 17
 In your CMakeLists.txt add the compile option:
 `add_compile_options(/std:c++latest)`
 
-## Directory Separators
+### Directory Separators
 Windows uses backslash `\` whereas Linux uses forward slash `/`. As we encounter path processing, we've been replacing them with the Python or Boost equivelents.
 
-## User directory
+### User directory
 Linux has a neat shortcut for refering to the users' home directory `~`. 
 
 Windows uses the environment variable `%USERPROFILE%` - use this whenever you see `~` in ROS documentation.
 
 ## Quote handling in command window
 Cmd.exe is the command processor of command window.  Single quotes are not used at all by the cmd.exe except in batch file to enclose the command to run within a FOR /F statement.  Cmd.exe handles quoting with double quotes.  This is different from Linux that uses single quote as quote character.  As encounter quoting on Windows, please use double quote.  The following example shows using double quotes around the message contents:
-``` 
+```no-highlight
 rostopic pub -1 /turtle1/cmd_vel geometry_msgs/Twist -- "[2.0, 0.0, 0.0]" "[0.0, 0.0, 1.8]"
 ```
 
@@ -29,14 +29,14 @@ To address this either:
   * Link folders from your C:\ drive to your workspaces.
 
 To link a folder on Windows, use the mklink to create a filesystem link from one drive to another.:
-``` 
+```no-highlight
 mkdir d:\workspaces
 mklink c:\workspaces d:\workspaces
 ```
 
 ### Symbol Visibility
 Windows and Linux handle symbol visibility differently. You may encounter a build error of the form:
-```
+```no-highlight
 error C2448: '__attribute__': function-style initializer appears to be a function definition
 'visibility': identifier not found
 ```
@@ -50,7 +50,7 @@ Please visit the Microsoft Documentation for more information on [Gflags](https:
 ### install Library TARGETS given no DESTINATION! 
 
 Windows will generate separate archives and librarys. To handle this, add an ARCHIVE destination:
-```
+```no-highlight
 install(
     TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -59,7 +59,7 @@ install(
 ### All Warnings
 Warnings are good. The options for selecting warning level are different. If you add specific compiler options for warnings, please add an MSVC selection. For the Visual Studio compiler, you'll use `/W3` for warning level 3 (or `/W4` which offers more warning options). If you would like to treat warnings as errors pass `/WX`. However, these warnings would need to be corrected before the compile will succeed.
 
-```
+```no-highlight
 if(MSVC)
   add_compile_options(/W3 /WX)
 else()
@@ -69,7 +69,7 @@ endif()
 
 You can disable specific warnings using `#pragma`:
 
-```
+```c
 #ifdef _MSC_VER
   #pragma warning(disable: 4244)
   #pragma warning(disable: 4661)
@@ -78,13 +78,13 @@ You can disable specific warnings using `#pragma`:
 ### Security Warnings
 Windows deprecates certain C APIs because they are inherently insecure. You will receive a message of the form:
 
-```
+```no-highlight
 warning C4996: 'xxx': This function or variable may be unsafe. Consider using xxx_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
 ```
 
 Consider using modern equivelents. If you cannot use a modern equivelent, you can add the following to your cmake files:
 
-```
+```no-highlight
 add_definitions("/D_CRT_SECURE_NO_WARNINGS")
 add_definitions("/D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS")
 ```
@@ -92,7 +92,7 @@ add_definitions("/D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS")
 ### C++ versioning
 Use CMake to set the C++ version:
 
-```
+```no-highlight
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
@@ -105,7 +105,7 @@ Linux automatically exports symbols. Windows, symbols are private by default. [C
 
 In your cmake:
 
-```
+```no-highlight
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 ```
 
@@ -143,7 +143,7 @@ The Microsoft compiler will optimize agressively. This can manifest in strange w
 ### Case sensitivity
 Linux is case sensitive, whereas Windows is not. We are trying to locate case sensitive areas and isolate them. This manifests in odd errors like this: 
 
-```
+```no-highlight
 RLException: multiple files named [turtlebot3_robot.launch] in package [turtlebot3_bringup]:
 - C:\ws\turtlebot_ws\install\share\turtlebot3_bringup\launch\turtlebot3_robot.launch
 - c:\ws\turtlebot_ws\install\share\turtlebot3_bringup\launch\turtlebot3_robot.launch
@@ -163,7 +163,7 @@ If you are producing a command line application which will be installed with Pip
 ## Errors
 ### gtest-NOTFOUND
 This occurs when linking against gtest instead of ${GTEST_LIBRARIES}
-```
+```no-highlight
   target_link_libraries( rtest
       ${GTEST_LIBRARIES}
       ${catkin_LIBRARIES}
@@ -192,7 +192,7 @@ Add the following before boost/asio.hpp:
 Add the following to the top of your file:
 
 ``` C++
-#define _USE_MATH_DEFINES 
+#define _USE_MATH_DEFINES
 ```
 
 or define it in the CMakeFile.exe
@@ -207,7 +207,7 @@ Use appropriate casts ensuring accuracy of the conversion.
 ### unreferenced parameters
 Either remove the variable, or reference it in a noop block
 
-```c++ 
+```c++
 uint8_t unused;
 unused;
 ```

--- a/docs/ROSAtMS/WinML.md
+++ b/docs/ROSAtMS/WinML.md
@@ -14,7 +14,7 @@ Requirements:
 The WinML ROS Node is distrubted as source. To consume it in your robot, clone the winml_tracker sources into your workspace.
 
 For example:
-```
+```no-highlight
 mkdir c:\workspace\winml_demo\src
 cd c:\workspace\winml_demo\src
 catkin_init_workspace
@@ -23,14 +23,14 @@ git clone https://github.com/ms-iot/winml_tracker
 
 Find or construct a suitible onnx model. For example, you can download [TinyYOLO from the Onnx Model Zoo](https://github.com/onnx/models/tree/master/vision/object_detection_segmentation/tiny_yolov2). 
 
-```
+```no-highlight
 choco upgrade curl
 curl https://onnxzoo.blob.core.windows.net/models/opset_8/tiny_yolov2/tiny_yolov2.tar.gz --output tiny_yolov2.tar.gz
 tar -xf tiny_yolov2.tar.gz
 ```
 
 Create a Launch file, which references the model.onnx file:
-``` xml
+```xml
 <launch>
   <arg name="onnx_model_path_arg" default="$(find winml_tracker)/testdata/model.onnx"/>
   <node pkg="winml_tracker" type="winml_tracker_node" name="winml_tracker" output="screen">
@@ -89,7 +89,7 @@ The WinML Publishes the following topics:
 ### /tracked_objects/image
 Outputs an image with highlighing if the debug property is set
 
-##/tracked_objects/
+### /tracked_objects/
 An array of `visualization_msgs::Marker` for found objects
 
 ### /detected_object

--- a/docs/Turtlebot/Turtlebot3.md
+++ b/docs/Turtlebot/Turtlebot3.md
@@ -10,7 +10,7 @@ The Turtlebot 3 uses a Lidar which requires the following driver.
 # Guide
 ## General notes
 The turtlebot documentation uses the unix command 'export' to set environment variables, instead use the following:
-```
+```no-highlight
 set TURTLEBOT3_MODEL=waffle
 ```
 > NOTE: The value of %TURTLEBOT3_MODEL% is case-sensitive.
@@ -39,7 +39,7 @@ ROS on Windows requires a x64 bit Windows 10 Desktop or Windows 10 IoT Enterpris
 ## Create a new workspace
 In a Command Window set up with the ROS environment, create a directory for your robot workspaces and a workspace for turtlebot.
 
-```
+```no-highlight
 mkdir c:\ws\turtlebot3\src
 cd c:\ws\turtlebot3\src
 catkin_init_workspace
@@ -63,14 +63,14 @@ Enter the COM port in the correct fields in the launch files below:
 
 *turtlebot3_bringup/launch/turtlebot3_core-win.launch*
 
-```
+```xml
 <node pkg="rosserial_python" type="serial_node.py" name="turtlebot3_core" output="screen">
     <param name="port" value="COMx"/>
 ```
 
 *turtlebot3_bringup/launch/turtlebot3_lidar-win.launch*
 
-```
+```xml
   <node pkg="hls_lfcd_lds_driver" type="hlds_laser_publisher" name="turtlebot3_lds" output="screen">
     <param name="port" value="COMy"/>
 ```
@@ -78,12 +78,12 @@ Enter the COM port in the correct fields in the launch files below:
 
 ## Build Nodes
 To build the turtlebot packages, enter the turtlebot3 workspace and build using the catkin build system.
-```
+```no-highlight
 :: make sure all required binaries installed.
 choco upgrade ros-melodic-desktop_full -y
 ```
 
-```
+```no-highlight
 :: build Turtlebot3 workspace.
 cd c:\ws\turtlebot3
 catkin_make
@@ -91,7 +91,7 @@ catkin_make
 
 Now inform ROS where to find your turtlebot code by merging the turtlebot install environment with the ROS environment. Please ensure you do this every time you open a command window. 
 
-```
+```no-highlight
 c:\ws\turtlebot3\devel\setup.bat
 ```
 
@@ -105,7 +105,7 @@ rViz is tool which allows you to visualize a representation of a robot, and proj
 
 To start the simulation, open one elevated command prompt:
 
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 c:\ws\turtlebot3\devel\setup.bat
 set TURTLEBOT3_MODEL=waffle
@@ -114,7 +114,7 @@ roslaunch turtlebot3_fake turtlebot3_fake.launch
 
 Then, open another elevated command prompt:
 
-```
+```no-highlight
 c:\opt\ros\melodic\x64\setup.bat
 c:\ws\turtlebot3\devel\setup.bat
 set TURTLEBOT3_MODEL=waffle
@@ -128,13 +128,13 @@ SLAM (Simultaneous localization and mapping) is a very popular application in th
 
 To start this demo, open an evelated command prompt:
 
-```
+```no-highlight
 :: make sure all required binaries installed.
 choco upgrade ros-melodic-desktop_full -y
 choco upgrade ros-melodic-cartographer_ros -y
 ```
 
-```
+```no-highlight
 :: run the demo.
 c:\opt\ros\melodic\x64\setup.bat
 c:\ws\turtlebot3\devel\setup.bat
@@ -154,8 +154,6 @@ In one command window, start `roscore`.
 
 In another command window, launch the turtlebot robot code.
 
-```
+```no-highlight
 roslaunch turtlebot3_bringup turtlebot3_robot.launch
 ```
-
-

--- a/docs/WhatsNew.md
+++ b/docs/WhatsNew.md
@@ -1,7 +1,7 @@
 # What's New
 
 ## January 2020
-## State of ROS on Windows
+### State of ROS on Windows
 ROS1 for Windows was announced generally available in May 2019. Since then it's use has continued to grow. Many companies are porting nodes to Windows. The Visual Studio Code extension has been incredibly well adopted within the community. 
 
 ### New Look for Documents

--- a/docs/tutorials/sick_s300/getting_started.md
+++ b/docs/tutorials/sick_s300/getting_started.md
@@ -1,3 +1,6 @@
+SICK S300 Safety Laser Scanner
+==============================
+
 In this post, I will show you how to get started with **SICK S300 Safety Laser Scanner** in a ROS workspace.
 I will begin with an empty workspace, add required ROS packages, define and run an exmaple ROS application, and check laser scan in the ROS visualization tools.
 
@@ -21,7 +24,7 @@ For more information, see [http://wiki.ros.org/cob_sick_s300](http://wiki.ros.or
 Firstly, you will need a `catkin` workspace to contain the driver package.
 Let's assume you are working on a empty workspace under `c:\s300_ws` and now you need to clone the driver package and its dependencies into the source folder:
 
-```
+```no-highlight
 :: change the directory to the source subfolder.
 c:\s300_ws> cd src
 
@@ -36,7 +39,7 @@ Now you have the required packages in your workspace.
 By ROS convention, it is common to manage the peripheral nodes in ROS launch files.
 However, since we begin this tutorial with an empty workspace, let's create a new package so we can add the ROS launch files later.
 
-```
+```no-highlight
 :: change the directory to the source subfolder.
 c:\s300_ws> cd src
 
@@ -49,7 +52,7 @@ c:\s300_ws\src> catkin_create_pkg my_pkg
 Let's build the workspace to produce the executables and binaries.
 And remember to run `setup.bat` to add the development space into the current environment.
 
-```
+```no-highlight
 :: Build the workspace
 c:\s300_ws> catkin_make
 
@@ -62,7 +65,7 @@ c:\s300_ws> devel\setup.bat
 At this moment, you are ready to add new ROS launch file for the new package.
 Let's add a new one called `my_pkg.launch`:
 
-```
+```no-highlight
 :: Change the directory to new package
 c:\s300_ws> roscd my_pkg
 
@@ -104,7 +107,7 @@ Before we move forward, let's take a look some important parameters to accommoda
 
 After everything is correctly configured, you are ready to run it.
 
-```
+```no-highlight
 :: Run the ROS launch file
 c:\s300_ws> roslaunch my_pkg my_pkg.launch
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,5 +33,6 @@ nav:
         - Source Installation: Build/source.md
     - Support:
         - Troubleshooting: GettingStarted/Troubleshooting.md
+        - Create Issue: https://github.com/ms-iot/rosonwindows/issues
 theme: readthedocs
 use_directory_urls: false


### PR DESCRIPTION
* Added `no-highlight` to drop the default highlighting for code blocks.

* Renamed `Moveit!` to `MoveIt` to respect the original spelling.

* Fixed some header indention.

* Added `GitHub` issue link.