### PR TITLE
Switch to Material for MkDocs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
       gh_pat: $(gh_userpat)
   - script: |
       pip install mkdocs
+      pip install mkdocs-material
       mkdocs --version
       mkdocs gh-deploy
 
@@ -37,5 +38,6 @@ jobs:
       versionSpec: '3.7.x'
   - script: |
       pip install mkdocs
+      pip install mkdocs-material
       mkdocs --version
       mkdocs build

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,6 @@ nav:
         - Troubleshooting: GettingStarted/Troubleshooting.md
         - Create Issue: https://github.com/ms-iot/rosonwindows/issues
         - Paid Support: https://aka.ms/ros/support
-theme: readthedocs
+theme: material
 use_directory_urls: false
 strict: true


### PR DESCRIPTION
The [Material for MKDocs](https://squidfunk.github.io/mkdocs-material/) theme is more friendly to the code block and navigation menu.

For example, here is what it looks like:
![image](https://user-images.githubusercontent.com/25241284/92665951-b99bf280-f2bc-11ea-8da3-6f52f1ab1671.png)
