### PR TITLE
[nav2] Switch to use the upstream branch for demo.

### DIFF
--- a/docs/ros2/nav2.md
+++ b/docs/ros2/nav2.md
@@ -70,8 +70,8 @@ mkdir c:\nav2_ws\src
 pushd c:\nav2_ws
 
 :: checkout the required source code.
-wget https://raw.githubusercontent.com/ms-iot/ROSOnWindows/master/docs/ros2/navigation2_foxy.repos
-vcs import src < navigation2.repos
+curl -o nav2.repos https://raw.githubusercontent.com/ms-iot/ROSOnWindows/master/docs/ros2/navigation2_foxy.repos
+vcs import src < nav2.repos
 ```
 
 ## Build and Activate the Navigation 2 Workspace

--- a/docs/ros2/navigation2_foxy.repos
+++ b/docs/ros2/navigation2_foxy.repos
@@ -1,16 +1,12 @@
 repositories:
-  navigation2:
-    type: git
-    url: https://github.com/ms-iot/navigation2.git
-    version: windows/0.4.2
   turtlebot3/turtlebot3:
     type: git
     url: https://github.com/ROBOTIS-GIT/turtlebot3.git
-    version: ros2
+    version: foxy-devel
   turtlebot3/turtlebot3_simulations:
     type: git
-    url: https://github.com/ms-iot/turtlebot3_simulations.git
-    version: windows/foxy-devel
+    url: https://github.com/ROBOTIS-GIT/turtlebot3_simulations.git
+    version: ros2-devel
   utils/DynamixelSDK:
     type: git
     url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git


### PR DESCRIPTION
* Switch to use ROBOTIS upstream repo.
* Remove Nav2 repo since it is part of the installation.
* Fix the code checkout instructions.

Fixes #268