### PR TITLE
Replace build status with the CI & release dashboard.

### DIFF
--- a/docs/Build/status.md
+++ b/docs/Build/status.md
@@ -1,0 +1,24 @@
+# ROS on Windows Status
+
+This is the latest CI and release status of projects under ROS on Windows.
+
+# Latest ROS on Windows Releases
+
+| ROS Distribution Name | Latest Build Version |
+|-----|-----|
+| ROS Melodic Morenia | [![ros-melodic-desktop_full package in public feed in Azure Artifacts](https://ros-win.feeds.visualstudio.com/bed058dd-46da-4029-bb85-25eae7674d09/_apis/public/Packaging/Feeds/970b9238-92b2-4bab-8448-2650b58df9ea/Packages/52eeb664-5f61-43bb-ab4d-f94887ea7ea2/Badge)](https://ros-win.visualstudio.com/ros-win/_packaging?_a=package&feed=970b9238-92b2-4bab-8448-2650b58df9ea&package=52eeb664-5f61-43bb-ab4d-f94887ea7ea2&preferRelease=true) |
+| ROS Noetic Ninjemys | [![ros-noetic-desktop_full package in public feed in Azure Artifacts](https://ros-win.feeds.visualstudio.com/bed058dd-46da-4029-bb85-25eae7674d09/_apis/public/Packaging/Feeds/970b9238-92b2-4bab-8448-2650b58df9ea/Packages/37273869-bc27-40bb-9cc0-e29d5a2d874d/Badge)](https://ros-win.visualstudio.com/ros-win/_packaging?_a=package&feed=970b9238-92b2-4bab-8448-2650b58df9ea&package=37273869-bc27-40bb-9cc0-e29d5a2d874d&preferRelease=true) |
+| ROS 2 Dashing Diademata | [![ros-dashing-desktop package in public feed in Azure Artifacts](https://ros-win.feeds.visualstudio.com/bed058dd-46da-4029-bb85-25eae7674d09/_apis/public/Packaging/Feeds/970b9238-92b2-4bab-8448-2650b58df9ea/Packages/4be3a571-c9bf-4efc-9cf3-e9d70ac163bf/Badge)](https://ros-win.visualstudio.com/ros-win/_packaging?_a=package&feed=970b9238-92b2-4bab-8448-2650b58df9ea&package=4be3a571-c9bf-4efc-9cf3-e9d70ac163bf&preferRelease=true) |
+| ROS 2 Eloquent Elusor | [![ros-eloquent-desktop package in public feed in Azure Artifacts](https://ros-win.feeds.visualstudio.com/bed058dd-46da-4029-bb85-25eae7674d09/_apis/public/Packaging/Feeds/970b9238-92b2-4bab-8448-2650b58df9ea/Packages/720f32e1-9020-4f87-952d-87686170ba20/Badge)](https://ros-win.visualstudio.com/ros-win/_packaging?_a=package&feed=970b9238-92b2-4bab-8448-2650b58df9ea&package=720f32e1-9020-4f87-952d-87686170ba20&preferRelease=true) |
+| ROS 2 Foxy Fitzroy | [![ros-foxy-desktop package in public feed in Azure Artifacts](https://ros-win.feeds.visualstudio.com/bed058dd-46da-4029-bb85-25eae7674d09/_apis/public/Packaging/Feeds/970b9238-92b2-4bab-8448-2650b58df9ea/Packages/f6fb7610-481d-4eae-a947-c71a624c9e34/Badge)](https://ros-win.visualstudio.com/ros-win/_packaging?_a=package&feed=970b9238-92b2-4bab-8448-2650b58df9ea&package=f6fb7610-481d-4eae-a947-c71a624c9e34&preferRelease=true) |
+
+# Project CI Status
+
+| Project Name | CI Status |
+|-----|-----|
+| [azure_kinect_ros_driver](https://github.com/microsoft/azure_kinect_ros_driver) | ![Azure_Kinect_ROS_Driver CI](https://github.com/microsoft/Azure_Kinect_ROS_Driver/workflows/Azure_Kinect_ROS_Driver%20CI/badge.svg?event=schedule) |
+| [ros_azure_iothub](https://github.com/microsoft/ros_azure_iothub) | ![CI](https://github.com/microsoft/ros_azure_iothub/workflows/CI/badge.svg?event=schedule) |
+| [ros_msft_camera](https://github.com/ms-iot/ros_msft_camera) | ![CI](https://github.com/ms-iot/ros_msft_camera/workflows/CI/badge.svg?event=schedule) |
+| [ros_msft_luis](https://github.com/ms-iot/ros_msft_luis) | ![CI](https://github.com/ms-iot/ros_msft_luis/workflows/CI/badge.svg?event=schedule) |
+| [winml_tracker](https://github.com/ms-iot/winml_tracker) | ![CI](https://github.com/ms-iot/winml_tracker/workflows/CI/badge.svg?event=schedule) |
+| [vscode-ros](https://github.com/ms-iot/vscode-ros) | ![.github/workflows/workflow.yml](https://github.com/ms-iot/vscode-ros/workflows/.github/workflows/workflow.yml/badge.svg?event=push) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ edit_uri: edit/master/docs/
 nav:
     - Home: index.md
     - What's New: WhatsNew.md
-    - Build Status: Build/buildfarm.md
+    - Build Status: Build/status.md
     - Get ROS:
         - ROS 1: GettingStarted/Setup.md
         - ROS 2: GettingStarted/SetupRos2.md


### PR DESCRIPTION
A release versions dashboard would make more sense to the ROS on Windows users.

And the scheduled CI status dashboard would make sense to the team to know anything requiring any attention. 